### PR TITLE
Raise an error if `load_spectrum` fails

### DIFF
--- a/astrodbkit2/spectra.py
+++ b/astrodbkit2/spectra.py
@@ -203,5 +203,6 @@ def load_spectrum(filename, spectra_format=None):
     except Exception as e:  # pylint: disable=broad-except, invalid-name
         print(f'Error loading {filename}: {e}')
         spec1d = filename
+        raise Exception(e) 
 
     return spec1d


### PR DESCRIPTION
Right now, if `load _spectrum` fails, it just returns the path to the spectrum. I think it would be more useful if it actually raises an error and passes along the error message. 